### PR TITLE
Add pytest test driver for snitch verilator examples

### DIFF
--- a/snitch/test.py
+++ b/snitch/test.py
@@ -13,7 +13,7 @@ def execute(cmd, cwd):
         if return_code:
             raise subprocess.CalledProcessError(return_code, cmd)
     for line in command(cmd, cwd):
-        print(line)
+        print(line, end="")
 
 
 @pytest.mark.parametrize("example", ["addf", "echo"])


### PR DESCRIPTION
This is a simple pytest thing to run examples.
I recommend running with `--capture=no`
to see all output.

Python subprocess wizards might want to check out what I did based on this:
https://stackoverflow.com/questions/4417546/constantly-print-subprocess-output-while-process-is-running
For some reason printing stuff with subprocesses is always so difficult for me