### PR TITLE
[WIP] Add dockerfile for new snitch, configure single compute core

### DIFF
--- a/snitch/docker/Dockerfile
+++ b/snitch/docker/Dockerfile
@@ -6,24 +6,37 @@
 
 FROM ghcr.io/pulp-platform/snitch@sha256:1a361160886ddee785ca809d0b9d30a283d0116b2761fd872ba9b69b82e2f2a6 as builder
 
+
 RUN mkdir /src \
- && wget -qO- https://github.com/pulp-platform/snitch/archive/b9fe5550e26ea878fb734cfc37d161f564252305.tar.gz | \
-    tar xz --strip-components 1 -C /src \
- # verilator
- && cd /src/hw/system/snitch_cluster \
- && make bin/snitch_cluster.vlt \
- # spike
- && cd /src/sw/vendor/riscv-isa-sim \
- && ./configure --prefix=/opt/snitch-spike \
- && make install \
- # clang+llvm+lld
- && mkdir -p /opt/snitch-llvm \
+ && wget -qO- https://github.com/pulp-platform/snitch_cluster/archive/ca5e74453ab08a7e3079aecfdf0547c97c98e247.tar.gz | \
+    tar xz --strip-components 1 -C /src
+## verilator
+COPY default.hjson /src/target/snitch_cluster/cfg/default.hjson
+RUN make -C /src/target/snitch_cluster bin/snitch_cluster.vlt 
+ #\
+ ## spike
+ ##&& cd /src/sw/vendor/riscv-isa-sim \
+ ##&& ./configure --prefix=/opt/snitch-spike \
+ ##&& make install \
+ ## clang+llvm+lld
+RUN mkdir -p /opt/snitch-llvm \
  && wget -qO- https://github.com/pulp-platform/llvm-project/releases/download/0.12.0/riscv32-pulp-llvm-ubuntu1804-0.12.0.tar.gz | \
     tar xz --strip-components=1 -C /opt/snitch-llvm
 
+FROM ghcr.io/pulp-platform/snitch@sha256:1a361160886ddee785ca809d0b9d30a283d0116b2761fd872ba9b69b82e2f2a6 as builder-2
+
+RUN mkdir /src \
+ && wget -qO- https://github.com/pulp-platform/snitch/archive/b9fe5550e26ea878fb734cfc37d161f564252305.tar.gz | \
+    tar xz --strip-components 1 -C /src
+ ## spike
+ RUN cd /src/sw/vendor/riscv-isa-sim \
+ && ./configure --prefix=/opt/snitch-spike \
+ && make install
+
+
 FROM ubuntu:18.04 as toolchain
-COPY --from=builder /src/hw/system/snitch_cluster/bin/snitch_cluster.vlt /opt/snitch-rtl/bin/snitch_cluster.vlt
-COPY --from=builder /opt/snitch-spike /opt/snitch-spike
+COPY --from=builder /src/target/snitch_cluster/bin/snitch_cluster.vlt /opt/snitch-rtl/bin/snitch_cluster.vlt
+COPY --from=builder-2 /opt/snitch-spike /opt/snitch-spike
 COPY --from=builder /opt/snitch-llvm /opt/snitch-llvm
 
 RUN apt-get -y update \

--- a/snitch/docker/default.hjson
+++ b/snitch/docker/default.hjson
@@ -1,0 +1,120 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Cluster configuration for a simple testbench system.
+{
+    nr_s1_quadrant: 1,
+    s1_quadrant: {
+        nr_clusters: 1,
+    },
+
+    cluster: {
+        boot_addr: 4096, // 0x1000
+        cluster_base_addr: 268435456, // 0x1000_0000
+        cluster_base_offset: 0, // 0x0
+        cluster_base_hartid: 0,
+        addr_width: 48,
+        data_width: 64,
+        tcdm: {
+            size: 128,
+            banks: 32,
+        },
+        cluster_periph_size: 64, // kB
+        zero_mem_size: 64, // kB
+        dma_data_width: 512,
+        dma_axi_req_fifo_depth: 3,
+        dma_req_fifo_depth: 3,
+        // Timing parameters
+        timing: {
+            lat_comp_fp32: 3,
+            lat_comp_fp64: 3,
+            lat_comp_fp16: 2,
+            lat_comp_fp16_alt: 2,
+            lat_comp_fp8: 1,
+            lat_comp_fp8_alt: 1,
+            lat_noncomp: 1,
+            lat_conv: 1,
+            lat_sdotp: 2,
+            fpu_pipe_config: "BEFORE"
+            narrow_xbar_latency: "CUT_ALL_PORTS",
+            wide_xbar_latency: "CUT_ALL_PORTS",
+            // Isolate the core.
+            register_core_req: true,
+            register_core_rsp: true,
+            register_offload_req: true,
+            register_offload_rsp: true
+        },
+        hives: [
+            // Hive 0
+            {
+                icache: {
+                    size: 8, // total instruction cache size in kByte
+                    sets: 2, // number of ways
+                    cacheline: 256 // word size in bits
+                },
+                cores: [
+                    { $ref: "#/compute_core_template" },
+                    { $ref: "#/dma_core_template" },
+                ]
+            }
+        ]
+    },
+    dram: {
+        // 0x8000_0000
+        address: 2147483648,
+        // 0x8000_0000
+        length: 2147483648
+    },
+    peripherals: {
+        clint: {
+            // 0xffff_0000
+            address: 4294901760,
+            // 0x0000_1000
+            length: 4096
+        },
+    },
+    // Templates.
+    compute_core_template: {
+        isa: "rv32imafd",
+        xssr: true,
+        xfrep: true,
+        xdma: false,
+        xf16: false,
+        xf16alt: false,
+        xf8: false,
+        xf8alt: false,
+        xfdotp: false,
+        xfvec: false,
+        num_int_outstanding_loads: 1,
+        num_int_outstanding_mem: 4,
+        num_fp_outstanding_loads: 4,
+        num_fp_outstanding_mem: 4,
+        num_sequencer_instructions: 16,
+        num_dtlb_entries: 1,
+        num_itlb_entries: 1,
+        // Enable division/square root unit
+        // Xdiv_sqrt: true,
+    },
+    dma_core_template: {
+        isa: "rv32imafd",
+        // Xdiv_sqrt: true,
+        # isa: "rv32ema",
+        xdma: true
+        xssr: false
+        xfrep: false
+        xf16: false,
+        xf16alt: false,
+        xf8: false,
+        xf8alt: false,
+        xfdotp: false,
+        xfvec: false,
+        num_int_outstanding_loads: 1,
+        num_int_outstanding_mem: 4,
+        num_fp_outstanding_loads: 4,
+        num_fp_outstanding_mem: 4,
+        num_sequencer_instructions: 16,
+        num_dtlb_entries: 1,
+        num_itlb_entries: 1,
+    }
+}


### PR DESCRIPTION
This PR tries to do two things:
* Update the dockerfile of snitch to use the newest github.com/pulp-platform/snitch_cluster repo instead of the deprecated github.com/pulp-platform/snitch monorepo.
* Configure the snitch_cluster to use just 1 compute core, this is more practical as simulations finish a lot quicker, and 8 compute cores are (right now) out of scope (also from accelerator POV btw)

Currently this snitch_cluster.vlt binary does not give the same performance as the one from the old repo. So I think I messed something up.
I'll try to diff this in the following days, until then any suggestions to clean up the above are very welcome!