### PR TITLE
Change configuration to single core

### DIFF
--- a/snitch/docker/Dockerfile
+++ b/snitch/docker/Dockerfile
@@ -8,9 +8,10 @@ FROM ghcr.io/pulp-platform/snitch@sha256:1a361160886ddee785ca809d0b9d30a283d0116
 
 RUN mkdir /src \
  && wget -qO- https://github.com/pulp-platform/snitch/archive/b9fe5550e26ea878fb734cfc37d161f564252305.tar.gz | \
-    tar xz --strip-components 1 -C /src \
+    tar xz --strip-components 1 -C /src
  # verilator
- && cd /src/hw/system/snitch_cluster \
+COPY single.core.hjson /src/hw/system/snitch_cluster/cfg/cluster.default.hjson
+RUN cd /src/hw/system/snitch_cluster \
  && make bin/snitch_cluster.vlt \
  # spike
  && cd /src/sw/vendor/riscv-isa-sim \

--- a/snitch/docker/single.core.hjson
+++ b/snitch/docker/single.core.hjson
@@ -1,0 +1,113 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Cluster configuration for a simple testbench system.
+{
+    nr_s1_quadrant: 1,
+    s1_quadrant: {
+        nr_clusters: 1,
+    },
+
+    cluster: {
+        boot_addr: 4096, // 0x1000
+        cluster_base_addr: 1048576, // 0x100000
+        cluster_base_offset: 0, // 0x0
+        cluster_base_hartid: 0,
+        addr_width: 48,
+        data_width: 64,
+        tcdm: {
+            size: 128,
+            banks: 32,
+        },
+        cluster_periph_size: 64, // kB
+        zero_mem_size: 64, // kB
+        dma_data_width: 512,
+        dma_axi_req_fifo_depth: 3,
+        dma_req_fifo_depth: 3,
+        // Timing parameters
+        timing: {
+            lat_comp_fp32: 3,
+            lat_comp_fp64: 3,
+            lat_comp_fp16: 2,
+            lat_comp_fp16_alt: 2,
+            lat_comp_fp8: 1,
+            lat_comp_fp8_alt: 1,
+            lat_noncomp: 1,
+            lat_conv: 1,
+            lat_sdotp: 2,
+            fpu_pipe_config: "BEFORE"
+            narrow_xbar_latency: "CUT_ALL_PORTS",
+            wide_xbar_latency: "CUT_ALL_PORTS",
+            // Isolate the core.
+            register_core_req: true,
+            register_core_rsp: true,
+            register_offload_req: true,
+            register_offload_rsp: true
+        },
+        hives: [
+            // Hive 0
+            {
+                icache: {
+                    size: 8, // total instruction cache size in kByte
+                    sets: 2, // number of ways
+                    cacheline: 128 // word size in bits
+                },
+                cores: [
+                    { $ref: "#/compute_core_template" },
+                    { $ref: "#/dma_core_template" },
+                ]
+            },
+        ]
+    },
+    dram: {
+        // 0x8000_0000
+        address: 2147483648,
+        // 0x8000_0000
+        length: 2147483648
+    },
+    peripherals: {
+        clint: {
+            // 0xffff_0000
+            address: 4294901760,
+            // 0x0000_1000
+            length: 4096
+        },
+    },
+    // Templates.
+    compute_core_template: {
+        isa: "rv32imafd",
+        xssr: true
+        xfrep: true
+        xf16: true,
+        xf16alt: true,
+        xf8: true,
+        xf8alt: true,
+        xfdotp: true,
+        xfvec: true,
+        num_int_outstanding_loads: 1,
+        num_int_outstanding_mem: 4,
+        num_fp_outstanding_loads: 4,
+        num_fp_outstanding_mem: 4,
+        num_sequencer_instructions: 16,
+        num_dtlb_entries: 1,
+        num_itlb_entries: 1,
+        // Enable division/square root unit
+        // Xdiv_sqrt: true,
+    },
+    dma_core_template: {
+        isa: "rv32ima",
+        // Xdiv_sqrt: true,
+        # isa: "rv32ema",
+        xdma: true
+        xssr: false
+        xfrep: false
+        num_int_outstanding_loads: 1,
+        num_int_outstanding_mem: 4,
+        num_fp_outstanding_loads: 4,
+        num_fp_outstanding_mem: 4,
+        num_sequencer_instructions: 16,
+        num_dtlb_entries: 1,
+        num_itlb_entries: 1,
+    }
+}


### PR DESCRIPTION
This PR removes 7 cores of the configuration while still using the old snitch repository, like so:
```hjson
hives: [
            // Hive 0
            {
                cores: [
                    { $ref: "#/compute_core_template" },
                    { $ref: "#/compute_core_template" },
                    { $ref: "#/compute_core_template" },
                    { $ref: "#/compute_core_template" },
                    # { $ref: "#/compute_core_template" },
                ]
            }
            // Hive 1
            {
                icache: {
                    size: 8, // total instruction cache size in kByte
                    sets: 2, // number of ways
                    cacheline: 128 // word size in bits
                },
                cores: [
                    { $ref: "#/compute_core_template" },
                    { $ref: "#/compute_core_template" },
                    { $ref: "#/compute_core_template" },
                    { $ref: "#/compute_core_template" },
                    { $ref: "#/dma_core_template" },
                ]
            },
        ]
```
Into:
```
hives: [
            // Hive 0
            {
                icache: {
                    size: 8, // total instruction cache size in kByte
                    sets: 2, // number of ways
                    cacheline: 128 // word size in bits
                },
                cores: [
                    { $ref: "#/compute_core_template" },
                    { $ref: "#/dma_core_template" },
                ]
            },
        ]
```
Now these are the performance numbers I get for `addf_13x26xf32_mliropt.x`:
| Commit                   | b9fe5550e26ea878fb734cfc37d161f564252305 | b9fe5550e26ea878fb734cfc37d161f564252305 |
|--------------------------|------------------------------------------|------------------------------------------|
| Config                   | Default                                  | 1CC 1DMA                                 |
| Repo                     | snitch                                   | snitch                                   |
| snitch_loads             |                                      921 |                                      923 |
| snitch_stores            |                                      886 |                                      886 |
| fpss_loads               |                                     1353 |                                     1353 |
| fpss_stores              |                                      338 |                                      338 |
| snitch_avg_load_latency  |                                  10.6743 |                                  10.2828 |
| snitch_occupancy         |                                   0.2059 |                                   0.2091 |
| snitch_fseq_rel_offloads |                                   0.3496 |                                   0.3494 |
| fseq_yield               |                                        1 |                                        1 |
| fseq_fpu_yield           |                                        1 |                                        1 |
| fpss_section_latency     |                                        0 |                                        0 |
| fpss_avg_fpu_latency     |                                   1.7327 |                                   1.7327 |
| fpss_avg_load_latency    |                                   3.0081 |                                   3.0081 |
| fpss_occupancy           |                                   0.1106 |                                   0.1123 |
| fpss_fpu_occupancy       |                                   0.0498 |                                   0.0505 |
| fpss_fpu_rel_occupancy   |                                   0.4501 |                                   0.4501 |
| cycles                   |                                    27796 |                                    27384 |
| total_ipc                |                                   0.3165 |                                   0.3214 |