### PR TITLE
Pin docker image in CI

### DIFF
--- a/.github/workflows/ci-kernels.yml
+++ b/.github/workflows/ci-kernels.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-and-run-kernels:
     runs-on: ubuntu-latest
-    container: ghcr.io/nazavode/snitch-toolchain:sha256:6c2860a12d9c790ad4bb4adf8cdb231ef3b60b056ad20e89f31a99efc54b67b6
+    container: ghcr.io/nazavode/snitch-toolchain:1.0
     steps:
       - uses: actions/checkout@v3
       - run: make install


### PR DESCRIPTION
In preparation for the big PR porting the whole thing to the new RTL/runtime, this pins the docker image used in CI to the current `latest`. 