### PR TITLE
Add reference to smallfloat spec

### DIFF
--- a/kernels/axpy/64xf32/ssr.c
+++ b/kernels/axpy/64xf32/ssr.c
@@ -40,9 +40,8 @@ void axpy(float a, float* x, float* y, float* z) {
     // deal with 2x float values per iteration would be to have
     // proper SIMD instructions. Since we are dealing with a *frugal*
     // architecture, the best we can do is use packed SIMD custom
-    // instructions. Beware that these instructions are not documented
-    // anywhere, the only source of information is the actual Snitch RTL
-    // and/or the Snitch LLVM repository.
+    // instructions:
+    // https://iis-git.ee.ethz.ch/smach/smallFloat-spec
     for (int i = 0; i < niter; ++i) {
         asm volatile(
             "vfmul.s %[vtmp], %[va], ft0\n"

--- a/kernels/axpy/64xf32/ssr_frep.c
+++ b/kernels/axpy/64xf32/ssr_frep.c
@@ -41,9 +41,8 @@ void axpy(float a, float* x, float* y, float* z) {
     // deal with 2x float values per iteration would be to have
     // proper SIMD instructions. Since we are dealing with a *frugal*
     // architecture, the best we can do is use packed SIMD custom
-    // instructions. Beware that these instructions are not documented
-    // anywhere, the only source of information is the actual Snitch RTL
-    // and/or the Snitch LLVM repository.
+    // instructions:
+    // https://iis-git.ee.ethz.ch/smach/smallFloat-spec
     asm volatile(
         "frep.o  %[nfrep], 2, 0, 0 \n"
         "vfmul.s %[vtmp], %[va], ft0\n"

--- a/kernels/axpy/64xf32/ssr_frep_unroll.c
+++ b/kernels/axpy/64xf32/ssr_frep_unroll.c
@@ -47,9 +47,8 @@ void axpy(float a, float* x, float* y, float* z) {
     // deal with 2x float values per iteration would be to have
     // proper SIMD instructions. Since we are dealing with a *frugal*
     // architecture, the best we can do is use packed SIMD custom
-    // instructions. Beware that these instructions are not documented
-    // anywhere, the only source of information is the actual Snitch RTL
-    // and/or the Snitch LLVM repository.
+    // instructions:
+    // https://iis-git.ee.ethz.ch/smach/smallFloat-spec
     asm volatile(
         "frep.o  %[nfrep], 16, 0, 0 \n"
         "vfmul.s %[vtmp0], %[va], ft0\n"


### PR DESCRIPTION
This PR adds proper references to the *smallfloat* spec, a.k.a. the packed SIMD + reduced precision extensions provided in the current Snitch we are targeting.