### PR TITLE
Use different dir for each verilator run

### DIFF
--- a/kernels/Makefile.kernels
+++ b/kernels/Makefile.kernels
@@ -5,16 +5,23 @@
 CFLAGS += -std=gnu11
 CFLAGS += -Wall -Wextra
 
+LOG_DIR = $<.logs
+
+.ONESHELL:
+
 %.x: %.o main.o data.o
 	$(LD) $(LDFLAGS) $^ -o $@
 
 sim_%: %
-	rm -fr ./logs/
-	$(VLTSIM) $<
+	rm -rf $(LOG_DIR) && mkdir -p $(LOG_DIR)
+	cd $(LOG_DIR)
+	$(VLTSIM) ../$<
+	mv logs/* .
+	rm -rf logs
+	cd --
 
 RUN = $(addprefix run_, $(TESTS))
 $(RUN): run_%: sim_%
-	mv logs $(subst sim_,,$<).logs
 
 all: $(TESTS)
 


### PR DESCRIPTION
The `logs` directory seems to be hardcoded in SystemVerilog 😢.
This causes clashes when trying to run multiple Verilator runs in the same directory.

This PR adds a temporary directory named after the executable, which is removed at the end of the verilator run and all trace files are moved where we currently expect them.
A bit of monkeying around, but it significantly reduces the total execution time per kernel directory, especially when running this on a multicore machine with lots of cores.