### PR TITLE
Add Makefile dependency to trace file generation

### DIFF
--- a/kernels/Makefile.kernels
+++ b/kernels/Makefile.kernels
@@ -12,14 +12,6 @@ LOG_DIR = $<.logs
 %.x: %.o main.o data.o
 	$(LD) $(LDFLAGS) $^ -o $@
 
-sim_%: %
-	rm -rf $(LOG_DIR) && mkdir -p $(LOG_DIR)
-	cd $(LOG_DIR)
-	$(VLTSIM) ../$<
-	mv logs/* .
-	rm -rf logs
-	cd --
-
 RUN = $(addprefix run_, $(TESTS))
 $(RUN): run_%: sim_%
 

--- a/snitch/Makefile.rules
+++ b/snitch/Makefile.rules
@@ -127,6 +127,18 @@ MLIROPTFLAGS += --reconcile-unrealized-casts
 
 # Trace rules
 
+sim_%: %.logs/trace_hart_00000000.dasm
+	
+
+.PRECIOUS: %.logs/trace_hart_00000000.dasm
+%.logs/trace_hart_00000000.dasm: %
+	rm -rf $(LOG_DIR) && mkdir -p $(LOG_DIR)
+	cd $(LOG_DIR)
+	$(VLTSIM) ../$<
+	mv logs/* .
+	rm -rf logs
+	cd --
+
 %.trace.txt %.trace.json: %.dasm
 	$(DASM) < $< | $(GENTRACE) --permissive -d $*.trace.json > $*.trace.txt
 


### PR DESCRIPTION
This connects via Make dependency rules the `sim_%` targets to traces (just `trace_hart_00000000.dasm` for now).
In turn, now the aforementioned trace file depends on the executable that generates it.

This avoids unnecessary Verilator runs when the executable hasn't been changed.