### PR TITLE
Allow abort of run script on any error

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
-VALID_ARGS=$(getopt -o h --long skip-clean,skip-build,skip-run,skip-results,help -- "$@")
+VALID_ARGS=$(getopt -o h --long abort-on-error,skip-clean,skip-build,skip-run,skip-results,help -- "$@")
 if [[ $? -ne 0 ]]; then
     exit 1;
 fi
 
+ABORT_ON_ERROR=0
 SKIP_CLEAN=0
 SKIP_BUILD=0
 SKIP_RUN=0
@@ -13,6 +14,10 @@ SKIP_RESULTS=0
 eval set -- "$VALID_ARGS"
 while [ : ]; do
   case "$1" in
+    --abort-on-error)
+        ABORT_ON_ERROR=1
+        shift
+        ;;
     --skip-clean)
         SKIP_CLEAN=1
         shift
@@ -33,11 +38,12 @@ while [ : ]; do
         ;;
     -h | --help)
         echo ""
-        echo "--skip-clean    Skip the clean step of build directories."
-        echo "--skip-build    Skip the build step."
-        echo "--skip-run      Skip the run step."
-        echo "--skip-results  Skip the results step."
-        echo "-h | --help     This help message."
+        echo "--abort-on-error  Abort upon the first error that occurs."
+        echo "--skip-clean      Skip the clean step of build directories."
+        echo "--skip-build      Skip the build step."
+        echo "--skip-run        Skip the run step."
+        echo "--skip-results    Skip the results step."
+        echo "-h | --help       This help message."
         shift
         exit 0
         ;;
@@ -66,6 +72,10 @@ KERNEL_DIRS=(
   "ssum/8x16xf32/"
   "ssum/14x26xf32/"
 )
+
+if [[ 1 -eq ${ABORT_ON_ERROR} ]]; then
+  set -e
+fi
 
 # Clean step
 


### PR DESCRIPTION
This PR adds a commandline flag in order to abort upon any error using the `bash` option: `set -e`.

This is useful because `run.sh` simply stitches together a bunch of other scripts, commands, etc., thus avoiding tedious and repetitive error checking by continuously interspersing:

```sh
if [[ $? -ne 0 ]]; then
  ...
fi
```

This will be enabled for the CI run of the script.