### PR TITLE
Add linalg version of double precision matmul 8x8 kernel

### DIFF
--- a/kernels/matmul/8x8xf64/Makefile
+++ b/kernels/matmul/8x8xf64/Makefile
@@ -4,5 +4,6 @@ include ../../../snitch/Makefile.rules
 
 TESTS =
 TESTS += baseline.x
+TESTS += linalg.x
 
 include ../../Makefile.kernels

--- a/kernels/matmul/8x8xf64/linalg.mlir
+++ b/kernels/matmul/8x8xf64/linalg.mlir
@@ -1,0 +1,12 @@
+func.func public @matmul(%X: memref<8x8xf64>,
+                         %Y: memref<8x8xf64>,
+                         %Z: memref<8x8xf64>) {
+  "linalg.generic"(%X, %Y, %Z) ({
+  ^bb0(%x: f64, %y: f64, %z: f64):
+    %r0 = arith.mulf %x, %y : f64
+    %r1 = arith.addf %z, %r0 : f64
+    "linalg.yield"(%r1) : (f64) -> ()
+  }) {indexing_maps = [affine_map<(m, n, k) -> (m, k)>, affine_map<(m, n, k) -> (k, n)>, affine_map<(m, n, k) -> (m,
+  n)>], iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>], operand_segment_sizes = array<i32: 2, 1>} : (memref<8x8xf64>, memref<8x8xf64>, memref<8x8xf64>) -> ()
+  func.return
+}

--- a/kernels/matmul/8x8xf64/linalg.xdsl.mlir
+++ b/kernels/matmul/8x8xf64/linalg.xdsl.mlir
@@ -1,0 +1,11 @@
+func.func public @matmul(%X: memref<8x8xf64>,
+                         %Y: memref<8x8xf64>,
+                         %Z: memref<8x8xf64>) {
+  "linalg.generic"(%X, %Y, %Z) ({
+  ^bb0(%x: f64, %y: f64, %z: f64):
+    %r0 = arith.mulf %x, %y : f64
+    %r1 = arith.addf %z, %r0 : f64
+    "linalg.yield"(%r1) : (f64) -> ()
+  }) {indexing_maps = [affine_map<(m, n, k) -> (m, k)>, affine_map<(m, n, k) -> (k, n)>, affine_map<(m, n, k) -> (m, n)>], iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>], operandSegmentSizes = array<i32: 2, 1>} : (memref<8x8xf64>, memref<8x8xf64>, memref<8x8xf64>) -> ()
+  func.return
+}


### PR DESCRIPTION
This PR:

- Adds 2 variations of the linalg double precision matmul (for the xdsl-opt and mlir-opt-16 pipelines respectively)



