### PR TITLE
Add configuration file for run script

### DIFF
--- a/scripts/all.cfg
+++ b/scripts/all.cfg
@@ -1,0 +1,6 @@
+saxpy/64xf32/
+ssum/8x16xf32/
+ssum/14x26xf32/
+dsum/8x16xf32/
+matmul/8x8xf64/
+matmul/16x16xf64/

--- a/scripts/run.cfg
+++ b/scripts/run.cfg
@@ -1,0 +1,2 @@
+dsum/8x16xf32/
+matmul/8x8xf64/


### PR DESCRIPTION
This PR:

- Adds configuration file for the run script (`run.sh`) which defaults to `run.cfg` within the same directory.
- Adds 2 configuration files for the currently active sets that we use

Resolves #47 