### PR TITLE
[ci] Use snitch-toolchain:latest tagged image

### DIFF
--- a/.github/workflows/ci-experiments.yml
+++ b/.github/workflows/ci-experiments.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run-experiments:
     runs-on: ubuntu-latest
-    container: ghcr.io/nazavode/snitch-toolchain:2.4
+    container: ghcr.io/nazavode/snitch-toolchain:latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci-kernels.yml
+++ b/.github/workflows/ci-kernels.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-and-run-kernels:
     runs-on: ubuntu-latest
-    container: ghcr.io/nazavode/snitch-toolchain:2.4
+    container: ghcr.io/nazavode/snitch-toolchain:latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ a clone of this repo inside it at `/src`:
 
 ```shell
 $ git clone https://github.com/opencompl/riscv-paper-experiments.git
-$ docker run --rm -ti --volume $PWD/riscv-paper-experiments:/src ghcr.io/nazavode/snitch-toolchain:2.3 bash
+$ docker run --rm -ti --volume $PWD/riscv-paper-experiments:/src ghcr.io/nazavode/snitch-toolchain:latest bash
 ```
 
 Alternatively, the current flow can be performed with:
 
 ```shell
-$ docker run --rm -ti --volume $PWD/riscv-paper-experiments:/src ghcr.io/nazavode/snitch-toolchain:2.3 /src/scripts/run.sh
+$ docker run --rm -ti --volume $PWD/riscv-paper-experiments:/src ghcr.io/nazavode/snitch-toolchain:latest /src/scripts/run.sh
 ```
 
 This builds the kernels, executes them with Verilator, process the traces from these runs and plots the results.


### PR DESCRIPTION
This PR introduces the use of the rolling tagged image `snitch-toolchain:latest` both for CI and docs.