### PR TITLE
Update workflow for running sanity kernel

### DIFF
--- a/.github/workflows/ci-kernels.yml
+++ b/.github/workflows/ci-kernels.yml
@@ -19,7 +19,7 @@ jobs:
           python3 -m venv venv
           . venv/bin/activate
           pip install -e .
-        working-directory: src/xdsl
+        working-directory: xdsl
       #- name: xDSL filecheck tests
         #run: |
           #/opt/python3.11/bin/python3 -m venv venv
@@ -30,9 +30,8 @@ jobs:
           #lit -v tests/filecheck
       - name: Build and run kernel 'saxpy'
         run: |
-          . /src/xdsl/venv/bin/activate
-          make all
-        working-directory: kernels/saxpy/64xf32
+          . xdsl/venv/bin/activate
+          make -C kernels/saxpy/64xf32 all
 # Note: disabling 'ssum' since it is taking 5x the time taken
 # by saxpy. Let's speed up things a bit, saxpy is fairly enough
 # of a smoke test.


### PR DESCRIPTION
Minimal changes to make the sanity kernel work for now.

I stopped running the xDSL test suite as per @AntonLydike's request and kept the xDSL installation to the basic requirements.