### PR TITLE
Add fpss_fpu_fmadd_issues counter to all results

### DIFF
--- a/scripts/csv_append.py
+++ b/scripts/csv_append.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import pandas as pd
+import sys
+import argparse
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Append columns from stdin CSV to target CSV file in-place."
+    )
+    parser.add_argument("target_csv", help="Target CSV file path")
+    args = parser.parse_args()
+    input_df = pd.read_csv(sys.stdin)
+    target_df = pd.read_csv(args.target_csv)
+
+    # Check for overlapping columns
+    existing_columns = [col for col in input_df.columns if col in target_df.columns]
+    if existing_columns:
+        raise ValueError(
+            f"Columns {', '.join(existing_columns)} already exist in target file."
+        )
+
+    target_df = pd.concat([target_df, input_df], axis=1)
+    target_df.to_csv(sys.stdout, index=False)

--- a/scripts/fpss_fpu_fmadd_issues.awk
+++ b/scripts/fpss_fpu_fmadd_issues.awk
@@ -1,0 +1,34 @@
+#!/usr/bin/awk -f
+# Count the number of fmadd.* instructions issued for each
+# profile section and output results in JSON format.
+
+BEGIN {
+    RS = "\n"
+    section = 0
+}
+
+/fmadd\.[fd]/{
+    counter[section]++
+}
+
+/csrr.+mcycle/{
+    section++
+    counter[section] = 0
+}
+
+END {
+    # JSON
+    # printf "[\n"
+    # for (i = 0; i <= section; i++) {
+    #     printf "  { \"fpss_fpu_fmadd_issues\": %d }", counter[i]
+    #     if (i < section) printf ","
+    #     printf "\n"
+    # }
+    # printf "]\n"
+
+    # CSV
+    printf "fpss_fpu_fmadd_issues\n"
+    for (i = 0; i <= section; i++) {
+        printf "%d\n", counter[i]
+    }
+}

--- a/snitch/Makefile.rules
+++ b/snitch/Makefile.rules
@@ -240,7 +240,11 @@ LOG_DIR = $<.logs
 	$(DASM) < $< | $(GENTRACE) --permissive -d $*.trace.json > $*.trace.txt
 
 %.csv: %.x.logs/logs/trace_hart_00000000.trace.json
-	python3 -c "import json,sys; data = json.load(open(sys.argv[1])); keys = sorted(data[1].keys()); print(','.join(keys)); print(','.join(str(data[1][k]) for k in keys))" $< > $@
+	set -e ;\
+	TMP=$$(mktemp) ;\
+	python3 -c "import json,sys; data = json.load(open(sys.argv[1])); keys = sorted(data[1].keys()); print(','.join(keys)); print(','.join(str(data[1][k]) for k in keys))" $< > $@ ;\
+	/src/scripts/fpss_fpu_fmadd_issues.awk $(patsubst %.json, %.txt, $<) | sed -n '1p;3p' | /src/scripts/csv_append.py $@ > $$TMP ;\
+	mv $$TMP $@ ;\
 
 
 define get_trace_targets


### PR DESCRIPTION
The number of FMA instructions executed is crucial to compute precise FLOP counts. This PR cherry-picks the addition of a new `fpss_fpu_fmadd_issues` performance counter from the [parameter exploration branch](https://github.com/opencompl/riscv-paper-experiments/tree/nazavode/matmul-shape-exploration) (that is currently too large to be reintegrated into `main`).