### PR TITLE
Move docker virtualenv out of submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# persistent virtualenv for docker image
+.venv-docker/
+
 # lit tests results
 **/.lit_test_times.txt
 tests/**/Output/*

--- a/snitch/docker/entrypoint.sh
+++ b/snitch/docker/entrypoint.sh
@@ -2,22 +2,12 @@
 
 set -euo pipefail
 
-VENV_DIR=venv_docker
-FORCE_VENV=0
+SETUP=/src/snitch/docker/venv.sh
 
-# This entrypoint expects the source repo to be mounted at /src,
-# if this is not the case, just skip xdsl virtualenv creation.
-if [[ -d /src/xdsl ]]; then
-  pushd /src/xdsl > /dev/null
-  if [[ 1 -eq ${FORCE_VENV} ]] || [[ ! -d ${VENV_DIR} ]] || [[ ! -f ${VENV_DIR}/bin/activate ]]; then
-    python3 -m venv ${VENV_DIR}
-    source ${VENV_DIR}/bin/activate
-    pip install -e .
-    pip install pandas
-  else
-    source ${VENV_DIR}/bin/activate
-  fi
-  popd
+if [ -f "${SETUP}" ]; then
+  source "${SETUP}"
+else
+  >&2 echo "WARNING: can't find source repo mounted at /src, brace for bad things"
 fi
 
 exec "$@"

--- a/snitch/docker/venv.sh
+++ b/snitch/docker/venv.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+VENV_DIR=/src/.venv-docker
+FORCE_VENV=0
+
+if [[ -d /src/xdsl ]]; then
+  pushd /src/xdsl > /dev/null
+  if [[ 1 -eq ${FORCE_VENV} ]] || [[ ! -d ${VENV_DIR} ]] || [[ ! -f ${VENV_DIR}/bin/activate ]]; then
+    python3 -m venv ${VENV_DIR}
+    source ${VENV_DIR}/bin/activate
+    pip install --upgrade pip
+    pip install -e .
+    pip install -r /src/scripts/requirements.txt
+  else
+    source ${VENV_DIR}/bin/activate
+  fi
+  popd
+fi
+


### PR DESCRIPTION
This PR moves the current docker virtualenv (`/src/xdsl/venv_docker`) to a git ignored location outside of submodules (`/src/.venv-docker`) to avoid changes in submodules that must be kept around but never committed.

**Note: [2.8 image](https://github.com/opencompl/riscv-paper-experiments/pkgs/container/snitch-toolchain/207692913?tag=2.8) already pushed, to be tagged as `latest` when this gets merged.**