### PR TITLE
Ignore all generated sources in parametrized kernel directories

### DIFF
--- a/kernels/dsum/.gitignore
+++ b/kernels/dsum/.gitignore
@@ -1,0 +1,4 @@
+# Ignores for parametric/templated kernels
+data.c
+data.h
+*.xdsl.mlir

--- a/kernels/fill/.gitignore
+++ b/kernels/fill/.gitignore
@@ -1,0 +1,4 @@
+# Ignores for parametric/templated kernels
+data.c
+data.h
+*.xdsl.mlir

--- a/kernels/matmul/.gitignore
+++ b/kernels/matmul/.gitignore
@@ -1,0 +1,4 @@
+# Ignores for parametric/templated kernels
+data.c
+data.h
+*.xdsl.mlir

--- a/kernels/pooling_nchw_max_d1_s2_3x3/.gitignore
+++ b/kernels/pooling_nchw_max_d1_s2_3x3/.gitignore
@@ -1,0 +1,4 @@
+# Ignores for parametric/templated kernels
+data.c
+data.h
+*.xdsl.mlir

--- a/kernels/pooling_nchw_sum_d1_s2_3x3/.gitignore
+++ b/kernels/pooling_nchw_sum_d1_s2_3x3/.gitignore
@@ -1,0 +1,4 @@
+# Ignores for parametric/templated kernels
+data.c
+data.h
+*.xdsl.mlir

--- a/kernels/relu/.gitignore
+++ b/kernels/relu/.gitignore
@@ -1,0 +1,4 @@
+# Ignores for parametric/templated kernels
+data.c
+data.h
+*.xdsl.mlir


### PR DESCRIPTION
This PR follows up on splitting a bigger set of changes into bite-sized PRs.