### PR TITLE
Pin image version in CI

### DIFF
--- a/.github/workflows/ci-pivoted.yml
+++ b/.github/workflows/ci-pivoted.yml
@@ -10,7 +10,7 @@ jobs:
   run-experiments:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/opencompl/snitch-toolchain:latest
+      image: ghcr.io/opencompl/snitch-toolchain:2.8
       options: --volume ${{ github.workspace }}:/src
     steps:
       - uses: actions/checkout@v3.5.0


### PR DESCRIPTION
This PR pins the Docker image version in CI to avoid relying on the rolling `latest` tag. The rationale comes from the little tip-tap dance  required to merge PRs that need a backward breaking Docker image to work correctly. For example, assume that in the PR, image version is pinned to the new, backward incompatible image version to keep things running correctly. When it's merge time, we either:

1. merge the PR with a pinned version, bump the `latest` tag on the image, and open a new PR that restores the `latest` tag in the CI yaml, or
2. bump the `latest` tag on the image temporarily breaking CI on `main`, quickly merge the PR (that is now pointing to `latest`)

By pinning a specific image version, each PR that needs a backward incompatible Docker image is self-consistent and updates to our Docker image don't break neither `main` nor branches.