### PR TITLE
include snitch_stream variants in regalloc csv

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -450,11 +450,9 @@ rule regalloc_stats_to_csv:
         import pandas as pd
 
         df = pd.read_json(input[0], lines=True)
-        df = df[df.variant == "linalg_xdsl"]
-        del df["preallocated_int"]
-        del df["preallocated_float"]
-        del df["variant"]
-        df.set_index(["impl", "params"], inplace=True)
+        df = df[df['variant'].isin(["linalg_xdsl", "snitch_stream"])]
+        df = df.drop(columns=["preallocated_int", "preallocated_float", "variant"])
+        df = df.set_index(["impl", "params"])
         df.to_csv(output[0], index=True)
 
 

--- a/results/regalloc.fast.csv
+++ b/results/regalloc.fast.csv
@@ -1,10 +1,14 @@
 impl,params,allocated_float,allocated_int
 conv2d_d1_s1_3x3,4x4xf64,8,9
+ddot,128xf64,6,8
+dense,8x8xf64,5,12
 fill,4x4xf64,3,4
 matmul,4x16x8xf64,8,9
+matmul_transb,4x16x16xf32,19,13
 pooling_nchw_max_d1_s2_3x3,4x4xf64,7,7
 pooling_nchw_sum_d1_s2_3x3,4x4xf64,7,7
 relu,4x4xf64,3,6
+relu,4x8xf32,3,6
 sum,4x4xf64,3,8
 sum,4x8xf32,3,8
 sum,8x8xf16,3,8


### PR DESCRIPTION
We can filter down the ones we don't want later, but it's worth including the f32 variants in the regalloc.