### PR TITLE
Fix legend and axis label positioning

### DIFF
--- a/plots-cgo2025-ae/heatmap.py
+++ b/plots-cgo2025-ae/heatmap.py
@@ -115,7 +115,7 @@ def generate_heatmaps(data: pd.DataFrame):
         ax.set_xlabel("$N$")
         ax.set_ylabel("$K$", rotation=0)
         plt.yticks(rotation=0)
-        ax.yaxis.set_label_coords(-0.05, 0.95, transform=None)
+        ax.yaxis.set_label_coords(-0.1, 0.95, transform=None)
         ax.xaxis.set_label_coords(1, -0.05, transform=None)
 
         # Skip every second x-axis label

--- a/plots-cgo2025-ae/plot_utils.py
+++ b/plots-cgo2025-ae/plot_utils.py
@@ -234,8 +234,8 @@ def plot_combined(
         for entry, (color, marker, linestyle) in legend_entries.items()
     ]
     labels = list(legend_entries.keys())
-    fig.legend(lines, labels, ncols=legend_cols, bbox_to_anchor=(0.5, 1.03))
+    fig.legend(lines, labels, ncols=legend_cols, bbox_to_anchor=(0.5, 1.0))
 
-    fig.tight_layout()
+    fig.tight_layout(pad=2.5)
 
     return fig


### PR DESCRIPTION
We can't use the LaTeX backend as it is not part of the toolchain image, so disabling `usetex` in matplotlib requires some moving around for positioning legends and axis labels.